### PR TITLE
Add Nuget nupkg signing

### DIFF
--- a/src/SecureSign.Core/Models/PathConfig.cs
+++ b/src/SecureSign.Core/Models/PathConfig.cs
@@ -49,5 +49,10 @@ namespace SecureSign.Core.Models
 		/// </summary>
 		public string SignTool { get; set; } = @"C:\Program Files (x86)\Windows Kits\10\bin\10.0.17763.0\x86\signtool.exe";
 
+		/// <summary>
+		/// Gets or sets the path to nuget.exe
+		/// </summary>
+		public string Nuget { get; set; } = @"nuget";
+
 	}
 }

--- a/src/SecureSign.Core/Models/PathConfig.cs
+++ b/src/SecureSign.Core/Models/PathConfig.cs
@@ -54,5 +54,10 @@ namespace SecureSign.Core.Models
 		/// </summary>
 		public string Nuget { get; set; } = @"nuget";
 
+		/// <summary>
+		/// Gets or sets the timestamp service url for Authenticode signing
+		/// </summary>
+		public string Timestamper { get; set; } = @"http://timestamp.digicert.com";
+
 	}
 }

--- a/src/SecureSign.Core/Signers/AuthenticodeSigner.cs
+++ b/src/SecureSign.Core/Signers/AuthenticodeSigner.cs
@@ -115,7 +115,7 @@ namespace SecureSign.Core.Signers
 					$"/p \"{CommandLineEncoder.Utils.EncodeArgText(certPassword)}\"",
 					$"/d \"{CommandLineEncoder.Utils.EncodeArgText(description)}\"",
 					$"/du \"{CommandLineEncoder.Utils.EncodeArgText(url)}\"",
-					"/tr http://timestamp.digicert.com",
+					$"/tr {_pathConfig.Timestamper}",
 					"/td sha256",
 					"/fd sha256",
 					$"\"{CommandLineEncoder.Utils.EncodeArgText(inputFile)}\"",
@@ -142,7 +142,7 @@ namespace SecureSign.Core.Signers
 					"-command",
 					"\"$Cert = New-Object System.Security.Cryptography.X509Certificates.X509Certificate2;",
 					$"$Cert.Import('{CommandLineEncoder.Utils.EncodeArgText(certFile)}','{CommandLineEncoder.Utils.EncodeArgText(certPassword)}',[System.Security.Cryptography.X509Certificates.X509KeyStorageFlags]::DefaultKeySet);",
-					$"Set-AuthenticodeSignature '{CommandLineEncoder.Utils.EncodeArgText(inputFile)}' $Cert -Timestamp http://timestamp.digicert.com\"",
+					$"Set-AuthenticodeSignature '{CommandLineEncoder.Utils.EncodeArgText(inputFile)}' $Cert -Timestamp {_pathConfig.Timestamper}\"",
 				}
 			);
 
@@ -170,7 +170,7 @@ namespace SecureSign.Core.Signers
 						"sign",
 						$"-CertificatePath \"{CommandLineEncoder.Utils.EncodeArgText(certFile)}\"",
 						$"-CertificatePassword \"{CommandLineEncoder.Utils.EncodeArgText(certPassword)}\"",
-						"-Timestamper http://timestamp.digicert.com",
+						$"-Timestamper {_pathConfig.Timestamper}",
 						$"\"{CommandLineEncoder.Utils.EncodeArgText(inputFile)}\"",
 					}
 				);
@@ -184,7 +184,7 @@ namespace SecureSign.Core.Signers
 						"sign",
 						$"-CertificatePath \"{CommandLineEncoder.Utils.EncodeArgText(certFile)}\"",
 						$"-CertificatePassword \"{CommandLineEncoder.Utils.EncodeArgText(certPassword)}\"",
-						"-Timestamper http://timestamp.digicert.com",
+						$"-Timestamper {_pathConfig.Timestamper}",
 						$"\"{CommandLineEncoder.Utils.EncodeArgText(inputFile)}\"",
 					}
 				);
@@ -253,7 +253,7 @@ namespace SecureSign.Core.Signers
 			var args = new List<string>
 			{
 				"sign",
-				"-ts http://timestamp.digicert.com",
+				$"-ts {_pathConfig.Timestamper}",
 				$"-n \"{CommandLineEncoder.Utils.EncodeArgText(description)}\"",
 				$"-i \"{CommandLineEncoder.Utils.EncodeArgText(url)}\"",
 				$"-pkcs12 \"{CommandLineEncoder.Utils.EncodeArgText(certFile)}\"",

--- a/src/SecureSign.Core/Signers/AuthenticodeSigner.cs
+++ b/src/SecureSign.Core/Signers/AuthenticodeSigner.cs
@@ -66,7 +66,7 @@ namespace SecureSign.Core.Signers
 				File.WriteAllBytes(certFile, exportedCert);
 				await input.CopyToFileAsync(inputFile);
 
-				if (fileExtention.Contains("nupkg"))
+				if (fileExtention == "nupkg")
 				{
 					return await SignUsingNugetAsync(inputFile, certFile, password);
 				}
@@ -190,7 +190,7 @@ namespace SecureSign.Core.Signers
 				);
 			}
 
-			// SignTool signs in-place, so just return the file we were given.
+			// nuget signs in-place, so just return the file we were given.
 			return File.OpenRead(inputFile);
 		}
 


### PR DESCRIPTION
This adds .nupkg signing via `nuget sign` to Authenticode signing. nuget.exe needs to be installed on not-windows and path set to it. (Nuget still requires mono on other platforms.)

I also made the timestamp service a configurable.