### PR TITLE
Stream CopyTo CanSeek

### DIFF
--- a/src/SecureSign.Core/Extensions/StreamExtensions.cs
+++ b/src/SecureSign.Core/Extensions/StreamExtensions.cs
@@ -38,7 +38,10 @@ namespace SecureSign.Core.Extensions
 		{
 			using (var fileStream = File.Create(filename))
 			{
-				stream.Seek(0, SeekOrigin.Begin);
+				if(stream.CanSeek)
+				{
+					stream.Seek(0, SeekOrigin.Begin);
+				}
 				await stream.CopyToAsync(fileStream);
 			}
 		}


### PR DESCRIPTION
Since an error was occurring with a Stream (http) that could not be Seeked, a determination was added to see if the Stream could be Seeked.
